### PR TITLE
METAGEN-83 Updating versions of dependencies and Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.3.1</version>
+            <version>6.8.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -86,19 +86,19 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.6.4</version>
+            <version>1.7.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.4</version>
+            <version>1.7.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>4.0.0.Final</version>
+            <version>4.2.3.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -119,7 +119,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.0</version>
+                <version>1.3.1</version>
                 <executions>
                     <execution>
                         <id>enforce-java</id>
@@ -166,7 +166,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.1</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
@@ -176,7 +176,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jaxb2-maven-plugin</artifactId>
-                <version>1.3.1</version>
+                <version>1.5</version>
                 <executions>
                     <execution>
                         <goals>
@@ -193,12 +193,12 @@
                     <dependency>
                         <groupId>javax.xml.bind</groupId>
                         <artifactId>jaxb-api</artifactId>
-                        <version>2.2.5</version>
+                        <version>2.2.9</version>
                     </dependency>
                     <dependency>
                         <groupId>com.sun.xml.bind</groupId>
                         <artifactId>jaxb-impl</artifactId>
-                        <version>2.1.13</version>
+                        <version>2.2.7</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -206,7 +206,7 @@
                 <inherited>true</inherited>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
+                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -219,7 +219,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.11</version>
+                <version>2.15</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <systemProperties>
@@ -240,7 +240,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.12</version>
+                <version>2.15</version>
                 <executions>
                     <execution>
                         <id>generate-test-report</id>
@@ -258,7 +258,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -275,7 +275,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>2.4</version>
                 <configuration>
                     <descriptors>
                         <descriptor>src/main/assembly/dist.xml</descriptor>
@@ -285,7 +285,7 @@
             <plugin>
                 <groupId>org.jboss.maven.plugins</groupId>
                 <artifactId>maven-jdocbook-plugin</artifactId>
-                <version>2.3.5</version>
+                <version>2.3.8</version>
                 <extensions>true</extensions>
                 <dependencies>
                     <dependency>
@@ -349,13 +349,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>2.4.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
                     <tagNameFormat>@{project.version}</tagNameFormat>
-                    <goals>package deploy javadoc:javadoc org.jboss.maven.plugins:maven-jdocbook-plugin:2.3.5:resources
-                        org.jboss.maven.plugins:maven-jdocbook-plugin:2.3.5:generate assembly:assembly
+                    <goals>package deploy javadoc:javadoc org.jboss.maven.plugins:maven-jdocbook-plugin:2.3.8:resources
+                        org.jboss.maven.plugins:maven-jdocbook-plugin:2.3.8:generate assembly:assembly
                     </goals>
                 </configuration>
             </plugin>

--- a/src/main/java/org/hibernate/jpamodelgen/xml/XmlMetaEntity.java
+++ b/src/main/java/org/hibernate/jpamodelgen/xml/XmlMetaEntity.java
@@ -82,7 +82,7 @@ public class XmlMetaEntity implements MetaEntity {
 	protected AccessTypeInformation accessTypeInfo;
 
 	public XmlMetaEntity(Entity ormEntity, String defaultPackageName, TypeElement element, Context context) {
-		this( ormEntity.getClazz(), defaultPackageName, element, context, ormEntity.getMetadataComplete() );
+		this( ormEntity.getClazz(), defaultPackageName, element, context, ormEntity.isMetadataComplete() );
 		this.attributes = ormEntity.getAttributes();
 		this.embeddableAttributes = null;
 		// entities can be directly initialised
@@ -95,7 +95,7 @@ public class XmlMetaEntity implements MetaEntity {
 				defaultPackageName,
 				element,
 				context,
-				mappedSuperclass.getMetadataComplete()
+				mappedSuperclass.isMetadataComplete()
 		);
 		this.attributes = mappedSuperclass.getAttributes();
 		this.embeddableAttributes = null;
@@ -104,7 +104,7 @@ public class XmlMetaEntity implements MetaEntity {
 	}
 
 	protected XmlMetaEntity(Embeddable embeddable, String defaultPackageName, TypeElement element, Context context) {
-		this( embeddable.getClazz(), defaultPackageName, element, context, embeddable.getMetadataComplete() );
+		this( embeddable.getClazz(), defaultPackageName, element, context, embeddable.isMetadataComplete() );
 		this.attributes = null;
 		this.embeddableAttributes = embeddable.getAttributes();
 	}


### PR DESCRIPTION
Here is an update of the dependencies and the Maven plugins.

I tested a mvn package javadoc:javadoc org.jboss.maven.plugins:maven-jdocbook-plugin:2.3.8:resources org.jboss.maven.plugins:maven-jdocbook-plugin:2.3.8:generate assembly:assembly without any problem (except for the failing tests being worked on in METAGEN-85).

I had to change a class due to a change in Jaxb but it's very minor.

Note: except for the JBoss specific plugins, we are using these versions for a while in our apps without any problem.
