### PR TITLE
Close persistence.xml after reading it

### DIFF
--- a/src/main/java/org/hibernate/jpamodelgen/xml/JpaDescriptorParser.java
+++ b/src/main/java/org/hibernate/jpamodelgen/xml/JpaDescriptorParser.java
@@ -122,15 +122,23 @@ public class JpaDescriptorParser {
 		if ( stream == null ) {
 			return null;
 		}
-
 		try {
-			Schema schema = xmlParserHelper.getSchema( PERSISTENCE_SCHEMA );
-			persistence = xmlParserHelper.getJaxbRoot( stream, Persistence.class, schema );
-		}
-		catch ( XmlParsingException e ) {
-			context.logMessage(
-					Diagnostic.Kind.WARNING, "Unable to parse persistence.xml: " + e.getMessage()
-			);
+			try {
+				Schema schema = xmlParserHelper.getSchema( PERSISTENCE_SCHEMA );
+				persistence = xmlParserHelper.getJaxbRoot( stream, Persistence.class, schema );
+			}
+			catch ( XmlParsingException e ) {
+				context.logMessage(
+						Diagnostic.Kind.WARNING, "Unable to parse persistence.xml: " + e.getMessage()
+				);
+			}
+		} finally {
+			try {
+				stream.close();
+			} catch (IOException e) {
+				context.logMessage(
+						Diagnostic.Kind.WARNING, "Unable to close persistence.xml: " + e.getMessage());
+			}
 		}
 		return persistence;
 	}


### PR DESCRIPTION
Using `hibernate-jpamodelgen-1.3.0.Final.jar` together with Eclipse Annotation Processing causes a problem. After the generation the project can't be cleaned any more. The error is: 

```
The project was not built due to "Could not delete '/Project1/bin/META-INF'.". Fix the problem, then try refreshing this project and building it since it may be inconsistent
```

It turns out, that the problem is unclosed persistence.xml file read by the generator. Closing it fixes the problem.
