### PR TITLE
Use https for gradlew download

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.7-bin.zip


### PR DESCRIPTION
Otherwise:
```
$ ./gradlew build
Downloading http://services.gradle.org/distributions/gradle-1.7-bin.zip

Exception in thread "main" java.io.IOException: Server returned HTTP response code: 403 for URL: http://services.gradle.org/distributions/gradle-1.7-bin.zip
        at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1919)
        at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1515)
        at org.gradle.wrapper.Download.downloadInternal(Download.java:63)
        at org.gradle.wrapper.Download.download(Download.java:49)
        at org.gradle.wrapper.Install.createDist(Install.java:51)
        at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:129)
        at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:48)
```